### PR TITLE
TGL-RVP: add definitions for RT711 (SDW) and RT1308 (SDW)

### DIFF
--- a/TGL-RVP/rtk_sdw_711_1308.asl
+++ b/TGL-RVP/rtk_sdw_711_1308.asl
@@ -1,0 +1,40 @@
+ /** @file
+  The definition block in ACPI table for RT711 under SoundWire Controller (link0) and
+  RT1308 amplifier in link1
+
+Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution.  The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+**/
+
+DefinitionBlock (
+  "",
+  "SSDT",
+   2,
+  "INTEL",
+  "RTKSDW",
+  0x1000
+  )
+{
+  External(\_SB.PC00.HDAS.SNDW, DeviceObj)
+
+  Scope (_SB.PC00.HDAS.SNDW) {
+        Device (RTK0) // RT711 on link0
+        {
+            Name (_ADR, 0x000021025D071100)  // _ADR: Address
+        }
+	Device (RTK1) // the first RT1308 on link1
+        {
+            Name (_ADR, 0x000122025D130800)  // _ADR: Address
+        }
+        Device (RTK2) // the second RT1308 on link1
+        {
+            Name (_ADR, 0x000120025D130800)  // _ADR: Address
+        }
+  }
+}


### PR DESCRIPTION
    RT711 is on link0 and two RT1308s on link1

