### PR TITLE
[RFC] ADL-RVP: add definitions for RT711 2xRT1316 RT714 in SDW mode

### DIFF
--- a/ADL-RVP/adl_sdca_3_in_1.asl
+++ b/ADL-RVP/adl_sdca_3_in_1.asl
@@ -1,0 +1,45 @@
+ /** @file
+  The definition block in ACPI table under SoundWire Controller,
+  connecting to Realtek AIOC Rev3.
+
+Copyright (c) 2019, Intel Corporation. All rights reserved.<BR>
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution.  The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+**/
+
+DefinitionBlock (
+  "",
+  "SSDT",
+   2,
+  "INTEL",
+  "ADLTabl",
+  0x1000
+  )
+{
+  External(\_SB.PC00.HDAS.SNDW, DeviceObj)
+
+  Scope (_SB.PC00.HDAS.SNDW) {
+	Device (RTK0)  // RT711 on link0
+        {
+            Name (_ADR, 0x000030025D071101)  // _ADR: Address
+        }
+	Device (RTK1) // RT1316-1 on link1
+        {
+            Name (_ADR, 0x000131025D131601)  // _ADR: Address
+        }
+	Device (RTK2) // RT714 on link2
+        {
+            Name (_ADR, 0x000230025D071401)  // _ADR: Address
+	}
+	Device (RTK3) // RT1316-2 on link3
+        {
+            Name (_ADR, 0x000330025D131601)  // _ADR: Address
+        }
+
+  }
+}


### PR DESCRIPTION
RT711 is on link0
RT1316-1 is on link1
RT1316-2 is on link2
RT714 is on link3

Signed-off-by: Libin Yang <libin.yang@intel.com>

-------------
updated:
RT711 is on link0
RT1316-1 is on link1
RT714 is on link2
RT1316-2 is on link3