### PR TITLE
asl: fix typo of rtk_sdw and rtk_sdw_i2c

### DIFF
--- a/ICL-RTK-3-in-1/rtk_sdw.asl
+++ b/ICL-RTK-3-in-1/rtk_sdw.asl
@@ -16,7 +16,7 @@ DefinitionBlock (
   "SSDT",
    2,
   "INTEL",
-  "RTKSDWTabl",
+  "RTKTabl",
   0x1000
   )
 {

--- a/TGL-RVP/rtk_sdw_i2c.asl
+++ b/TGL-RVP/rtk_sdw_i2c.asl
@@ -17,7 +17,7 @@ DefinitionBlock (
   "SSDT",
    2,
   "INTEL",
-  "RTKSDWTabl",
+  "RTKTabl",
   0x1000
   )
 {


### PR DESCRIPTION
In DefinitionBlock, the OEM Table ID cannot exceed 8 characters.

Signed-off-by: Libin Yang <libin.yang@intel.com>