### PR TITLE
TGL: add defaults for HP Spectre x360

### DIFF
--- a/TGL/HP-spectre-360.asl
+++ b/TGL/HP-spectre-360.asl
@@ -1,0 +1,35 @@
+ /** @file
+  The definition block in ACPI table four SoundWire devices on HP Spectre x360
+
+Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution.  The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+**/
+
+DefinitionBlock (
+  "",
+  "SSDT",
+   2,
+  "INTEL",
+  "RTKSDWTa",
+  0x1000
+  )
+{
+  External(\_SB.PC00.HDAS.SNDW, DeviceObj)
+
+  Scope (_SB.PC00.HDAS.SNDW) {
+	Device (RTK0)  // RT711 on link0
+        {
+            Name (_ADR, 0x000020025D071100)  // _ADR: Address
+        }
+	Device (RTK1) // RT1308 on link1
+        {
+            Name (_ADR, 0x000120025D130800) // _ADR: Address
+        }
+  }
+}


### PR DESCRIPTION
The DSDT on the HP Spectre x360 is just wrong, the RT711 and RT1308
are not exposed to the OS.

This initrd override table is needed if the kernel doesn't provide the
DMI quirks (before 5.13)

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>