### PR TITLE
MTL: add definitions for RT5682

### DIFF
--- a/MTL-RVP/rt5682-i2s.asl
+++ b/MTL-RVP/rt5682-i2s.asl
@@ -1,0 +1,55 @@
+/** @file
+  The definition block in ACPI table for rt5682 device under I2C3 Controller
+
+Copyright (c) 2015, Intel Corporation. All rights reserved.<BR>
+  This program and the accompanying materials
+  are licensed and made available under the terms and conditions of the BSD License
+  which accompanies this distribution.  The full text of the license may be found at
+  http://opensource.org/licenses/bsd-license.php
+
+  THE PROGRAM IS DISTRIBUTED UNDER THE BSD LICENSE ON AN "AS IS" BASIS,
+  WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+**/
+
+DefinitionBlock (
+  "",
+  "SSDT",
+   2,
+  "INTEL ",
+  "5682Tabl",
+  0x1000
+  )
+{
+  External(\_SB.PC00.I2C3, DeviceObj)
+
+  Scope (\_SB.PC00.I2C3) {
+            Device (RTKX)
+            {
+                Name (_ADR, Zero)  // _ADR: Address
+                Name (_HID, "10EC5682" /* Realtek I2S Audio Codec */)  // _HID: Hardware ID
+                Name (_CID, "10EC5682" /* Realtek I2S Audio Codec */)  // _CID: Compatible ID
+                Name (_DDN, "Realtek Codec Controller ")  // _DDN: DOS Device Name
+                Name (_UID, One)  // _UID: Unique ID
+                Method (_CRS, 0, Serialized)  // _CRS: Current Resource Settings
+                {
+                    Name (SBUF, ResourceTemplate ()
+                    {
+                        I2cSerialBus (0x001A, ControllerInitiated, 0x00061A80,
+                            AddressingMode7Bit, "\\_SB.PC00.I2C3",
+                            0x00, ResourceConsumer, ,
+                            )
+                    })
+                    Return (SBUF) /* \_SB_PC00.I2C3.RTKX._CRS.SBUF */
+                }
+
+                Method (_STA, 0, NotSerialized)  // _STA: Status
+                {
+                        Return (0x0F)
+                }
+
+                Method (_DIS, 0, NotSerialized)  // _DIS: Disable Device
+                {
+                }
+         }
+  }
+}


### PR DESCRIPTION
Add RT5682 I2S codec to I2C3.

But after run this device hasn't been exposed by ACPI yet: 
```
$sudo ./acpi-add MTL-RVP/rt5682-i2s.asl
-- generating rt5682-i2s.asl
MTL-RVP/rt5682-i2s.asl     26:             Device (RTKX)
Warning  3073 -                       Multiple types ^  (Device object requires either a _HID or _ADR, but not both)
MTL-RVP/rt5682-i2s.asl     35:                     Name (SBUF, ResourceTemplate ()
Remark   2173 -                                            ^ Creation of named objects within a method is highly inefficient, use globals or method local variables instead (\_SB.PC00.I2C3.RTKX._CRS)
Added 1 asl files
Update initramfs...
update-initramfs: Generating /boot/initrd.img-6.4.0-rc3-daily-default-20230611-0-g9fd7ca43e68c
```
But after I reboot the device by `$sudo init 6`, I found the device is not on i2c bus
```
$ll /sys/bus/i2c/devices/
total 0
drwxr-xr-x 2 root root 0 Jun 20 08:12 ./
drwxr-xr-x 4 root root 0 Jun 20 08:12 ../
lrwxrwxrwx 1 root root 0 Jun 20 08:12 i2c-0 -> ../../../devices/pci0000:00/0000:00:1f.4/i2c-0/
lrwxrwxrwx 1 root root 0 Jun 20 08:12 i2c-1 -> ../../../devices/pci0000:00/0000:00:15.0/i2c_designware.0/i2c-1/
lrwxrwxrwx 1 root root 0 Jun 20 08:12 i2c-2 -> ../../../devices/pci0000:00/0000:00:15.1/i2c_designware.1/i2c-2/
lrwxrwxrwx 1 root root 0 Jun 20 08:12 i2c-3 -> ../../../devices/pci0000:00/0000:00:15.2/i2c_designware.2/i2c-3/
lrwxrwxrwx 1 root root 0 Jun 20 08:12 i2c-4 -> ../../../devices/pci0000:00/0000:00:15.3/i2c_designware.3/i2c-4/
lrwxrwxrwx 1 root root 0 Jun 20 08:12 i2c-5 -> ../../../devices/pci0000:00/0000:00:19.0/i2c_designware.4/i2c-5/
lrwxrwxrwx 1 root root 0 Jun 20 08:12 i2c-6 -> ../../../devices/pci0000:00/0000:00:19.1/i2c_designware.5/i2c-6/
lrwxrwxrwx 1 root root 0 Jun 20 08:12 i2c-INT3472:0d -> ../../../devices/pci0000:00/0000:00:15.1/i2c_designware.1/i2c-2/i2c-INT3472:0d/
lrwxrwxrwx 1 root root 0 Jun 20 08:12 i2c-INT34C2:00 -> ../../../devices/pci0000:00/0000:00:15.3/i2c_designware.3/i2c-4/i2c-INT34C2:00/
lrwxrwxrwx 1 root root 0 Jun 20 08:12 i2c-INTC10B9:00 -> ../../../devices/pci0000:00/0000:00:15.3/i2c_designware.3/i2c-4/i2c-INTC10B9:00/
```
Could all devices under i2c-3 is disabled by something in DSDT?